### PR TITLE
Add label to Machine when it is a healthy member

### DIFF
--- a/controllers/machines.go
+++ b/controllers/machines.go
@@ -1,0 +1,126 @@
+package controllers
+
+import (
+	"context"
+
+	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
+	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/collections"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TODO(g-gaston): remove this once we have a stable CAPI repo that contains this,
+// MachineEtcdReadyLabelName is the label set on machines that have succesfully joined the etcd cluster.
+const MachineEtcdReadyLabelName = "cluster.x-k8s.io/etcd-ready"
+
+type etcdMachines map[string]etcdMachine
+
+// endpoints returns all the API endpoints for the machines that have one available.
+func (e etcdMachines) endpoints() []string {
+	endpoints := make([]string, 0, len(e))
+	for _, m := range e {
+		if m.endpoint != "" {
+			endpoints = append(endpoints, m.endpoint)
+		}
+	}
+
+	return endpoints
+}
+
+// etcdMachine represents a Machine that should be a member of an etcd cluster.
+type etcdMachine struct {
+	*clusterv1.Machine
+	endpoint    string
+	listening   bool
+	healthError error
+}
+
+func (e etcdMachine) healthy() bool {
+	return e.listening && e.healthError == nil
+}
+
+// updateMachinesEtcdReadyLabel adds the etcd-ready label to the machines that have joined the etcd cluster.
+func (r *EtcdadmClusterReconciler) updateMachinesEtcdReadyLabel(ctx context.Context, log logr.Logger, machines etcdMachines) error {
+	for _, m := range machines {
+		if _, ok := m.Labels[MachineEtcdReadyLabelName]; ok {
+			continue
+		}
+
+		if !m.healthy() {
+			continue
+		}
+
+		m.Labels[MachineEtcdReadyLabelName] = "true"
+		if err := r.Client.Update(ctx, m.Machine); err != nil {
+			return errors.Wrapf(err, "adding etcd ready label to machine %s", m.Name)
+		}
+	}
+
+	return nil
+}
+
+// checkOwnedMachines verifies the health of all etcd members.
+func (r *EtcdadmClusterReconciler) checkOwnedMachines(ctx context.Context, log logr.Logger, etcdadmCluster *etcdv1.EtcdadmCluster, cluster *clusterv1.Cluster) (etcdMachines, error) {
+	ownedMachines, err := r.getCurrentOwnedMachines(ctx, etcdadmCluster, cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	machines := make(etcdMachines, len(ownedMachines))
+	for k, machine := range ownedMachines {
+		m := etcdMachine{Machine: machine}
+		endpoint := getMachineEtcdEndpoint(machine)
+		if endpoint == "" {
+			machines[k] = m
+			continue
+		}
+
+		err := r.performEndpointHealthCheck(ctx, cluster, endpoint, true)
+		// This is not ideal, performEndpointHealthCheck uses an error to signal both a not ready/unhealthy member
+		// and also transient errors when performing such check.
+		// Ideally we would separate these 2 so we can abort on error and mark as unhealthy separetly
+		m.healthError = err
+		if errors.Is(err, portNotOpenErr) {
+			log.Info("Machine is not listening yet, this is probably transient, while etcd starts", "endpoint", endpoint)
+		} else {
+			m.listening = true
+		}
+
+		machines[k] = m
+	}
+
+	return machines, nil
+}
+
+// getCurrentOwnedMachines lists all the owned machines by the etcdadm cluster.
+func (r *EtcdadmClusterReconciler) getCurrentOwnedMachines(ctx context.Context, etcdadmCluster *etcdv1.EtcdadmCluster, cluster *clusterv1.Cluster) (collections.Machines, error) {
+	var client client.Reader
+	if conditions.IsFalse(etcdadmCluster, etcdv1.EtcdMachinesSpecUpToDateCondition) {
+		// During upgrade with current logic, outdated machines don't get deleted right away.
+		// the controller removes their etcdadmCluster ownerRef and updates the Machine. So using uncachedClient here will fetch those changes
+		client = r.uncachedClient
+	} else {
+		client = r.Client
+	}
+	etcdMachines, err := collections.GetFilteredMachinesForCluster(ctx, client, cluster, EtcdClusterMachines(cluster.Name, etcdadmCluster.Name))
+	if err != nil {
+		return nil, errors.Wrap(err, "Error filtering machines for etcd cluster")
+	}
+	ownedMachines := etcdMachines.Filter(collections.OwnedMachines(etcdadmCluster))
+
+	return ownedMachines, nil
+}
+
+// getMachineEtcdEndpoint constructs the full API url for an etcd member Machine.
+// If the Machine doesn't have yet the right address, it returns empty string.
+func getMachineEtcdEndpoint(machine *clusterv1.Machine) string {
+	address := getEtcdMachineAddress(machine)
+	if address == "" {
+		return ""
+	}
+
+	return getMemberClientURL(address)
+}

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -7,35 +7,19 @@ import (
 	"strings"
 
 	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
-	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/util/collections"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *EtcdadmClusterReconciler) updateStatus(ctx context.Context, ec *etcdv1.EtcdadmCluster, cluster *clusterv1.Cluster) error {
+func (r *EtcdadmClusterReconciler) updateStatus(ctx context.Context, ec *etcdv1.EtcdadmCluster, cluster *clusterv1.Cluster, ownedMachines etcdMachines) error {
 	log := r.Log.WithName(ec.Name)
 	selector := EtcdMachinesSelectorForCluster(cluster.Name, ec.Name)
 	// Copy label selector to its status counterpart in string format.
 	// This is necessary for CRDs including scale subresources.
 	ec.Status.Selector = selector.String()
 
-	var etcdMachines collections.Machines
-	var err error
-	if conditions.IsFalse(ec, etcdv1.EtcdMachinesSpecUpToDateCondition) {
-		// During upgrade with current logic, outdated machines don't get deleted right away.
-		// the controller removes their etcdadmCluster ownerRef and updates the Machine. So using uncachedClient here will fetch those changes
-		etcdMachines, err = collections.GetFilteredMachinesForCluster(ctx, r.uncachedClient, cluster, EtcdClusterMachines(cluster.Name, ec.Name))
-	} else {
-		etcdMachines, err = collections.GetFilteredMachinesForCluster(ctx, r.Client, cluster, EtcdClusterMachines(cluster.Name, ec.Name))
-	}
-	if err != nil {
-		return errors.Wrap(err, "Error filtering machines for etcd cluster")
-	}
-	ownedMachines := etcdMachines.Filter(collections.OwnedMachines(ec))
 	log.Info("following machines owned by this etcd cluster:")
 	for _, machine := range ownedMachines {
 		fmt.Printf("%s ", machine.Name)
@@ -59,26 +43,26 @@ func (r *EtcdadmClusterReconciler) updateStatus(ctx context.Context, ec *etcdv1.
 		conditions.MarkFalse(ec, etcdv1.EtcdClusterResizeCompleted, etcdv1.EtcdScaleDownInProgressReason, clusterv1.ConditionSeverityWarning, "Scaling up etcd cluster to %d replicas (actual %d)", desiredReplicas, readyReplicas)
 		return nil
 	}
-
 	conditions.MarkTrue(ec, etcdv1.EtcdClusterResizeCompleted)
 
-	endpoints := getMachinesEndpoints(log, ownedMachines)
-	if len(endpoints) == 0 {
-		return nil
-	}
-
-	log.Info("Running healthcheck on machines", "endpoints", endpoints)
-	if machinesReady, err := r.performMachinesHealthCheck(ctx, log, endpoints, cluster); err != nil {
-		ec.Status.Ready = false
-		return err
-	} else if !machinesReady {
-		return nil
+	for _, m := range ownedMachines {
+		if !m.healthy() {
+			if m.listening {
+				// The machine is listening but not ready/unhealthy
+				ec.Status.Ready = false
+				return m.healthError
+			} else {
+				// The machine is not listening, probably transient while etcd starts
+				return nil
+			}
+		}
 	}
 
 	// etcd ready when all machines have address set
 	ec.Status.Ready = true
 	conditions.MarkTrue(ec, etcdv1.EtcdEndpointsAvailable)
 
+	endpoints := ownedMachines.endpoints()
 	sort.Strings(endpoints)
 	currEndpoints := strings.Join(endpoints, ",")
 
@@ -109,36 +93,4 @@ func (r *EtcdadmClusterReconciler) updateStatus(ctx context.Context, ec *etcdv1.
 	ec.Status.CreationComplete = true
 
 	return nil
-}
-
-func getMachinesEndpoints(log logr.Logger, machines collections.Machines) []string {
-	endpoints := make([]string, 0, len(machines))
-	for _, m := range machines {
-		log.Info("Checking if machine has address set for healthcheck", "machine", m.Name)
-		if len(m.Status.Addresses) == 0 {
-			log.Info("No address set in machine yet", "machine", m.Name)
-			return nil
-		}
-
-		currentEndpoint := getMemberClientURL(getEtcdMachineAddress(m))
-		endpoints = append(endpoints, currentEndpoint)
-	}
-
-	return endpoints
-}
-
-func (r *EtcdadmClusterReconciler) performMachinesHealthCheck(ctx context.Context, log logr.Logger, endpoints []string, cluster *clusterv1.Cluster) (healthy bool, err error) {
-	for _, endpoint := range endpoints {
-		err := r.performEndpointHealthCheck(ctx, cluster, endpoint, true)
-		if errors.Is(err, portNotOpenErr) {
-			log.Info("Machine is not listening yet, this is probably transient, while etcd starts", "endpoint", endpoint)
-			return false, nil
-		}
-
-		if err != nil {
-			return false, err
-		}
-	}
-
-	return true, nil
 }


### PR DESCRIPTION
*Description of changes:*

This allows other parts of the system to react when the machines become healthy members of the etcd cluster. For example, the Machine controller can use this to determine when to mark the machine as running.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
