### PR TITLE
Fix etcd cluster status endpoint always empty

### DIFF
--- a/controllers/machines.go
+++ b/controllers/machines.go
@@ -86,6 +86,7 @@ func (r *EtcdadmClusterReconciler) checkOwnedMachines(ctx context.Context, log l
 		if errors.Is(err, portNotOpenErr) {
 			log.Info("Machine is not listening yet, this is probably transient, while etcd starts", "endpoint", endpoint)
 		} else {
+			m.endpoint = endpoint
 			m.listening = true
 		}
 


### PR DESCRIPTION
*Issue #, if available:*

After https://github.com/aws/etcdadm-controller/pull/15 merges, the etcd controller log shows the

```
1.6733064147977715e+09  INFO    controllers.EtcdadmCluster      Performing healthcheck on       {"endpoint": "https://192.168.1.4:2379/health"}
1.673306414800087e+09   INFO    controllers.EtcdadmCluster      Etcd member ready       {"member": "https://192.168.1.4:2379"}
1.6733064148008087e+09  INFO    controllers.EtcdadmCluster      Performing healthcheck on       {"endpoint": "https://192.168.1.3:2379/health"}
1.6733064148838718e+09  INFO    controllers.EtcdadmCluster      Etcd member ready       {"member": "https://192.168.1.3:2379"}
1.6733064148849528e+09  INFO    controllers.EtcdadmCluster.joeywang-etcd        following machines owned by this etcd cluster:
1.6733064148853416e+09  INFO    controllers.EtcdadmCluster.joeywang-etcd        Comparing current and previous endpoints
1.6733064156683114e+09  INFO    controllers.EtcdadmCluster      Skipping healthcheck because Endpoints are empty        {"Endpoints": ""}
1.673306445653081e+09   INFO    controllers.EtcdadmCluster      Skipping healthcheck because Endpoints are empty        {"Endpoints": ""}
1.6733064756528955e+09  INFO    controllers.EtcdadmCluster      Skipping healthcheck because Endpoints are empty        {"Endpoints": ""}
```

After all etcd members are ready, the etcd controller goes into infinite loop where the etcd cluster.status.endpoint is empty.

Realize we miss to set `etcdMachine.endpoint` so that the `func (e etcdMachines) endpoints() []string` always returns empty `[]string{}` and the `EtcdadmCluster.Status.Endpoints` will never be set.




*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
