### PR TITLE
Check for certs available before triggering health checks

### DIFF
--- a/controllers/certs.go
+++ b/controllers/certs.go
@@ -140,6 +140,9 @@ func (r *EtcdadmClusterReconciler) getCACert(ctx context.Context, cluster *clust
 		return []byte{}, errors.Wrap(err, "error looking up external etcd CA certs")
 	}
 	if caCertKey := caCert.GetByPurpose(secret.ManagedExternalEtcdCA); caCertKey != nil {
+		if caCertKey.KeyPair == nil {
+			return []byte{}, errors.New("ca cert key pair not found for cluster")
+		}
 		return caCertKey.KeyPair.Cert, nil
 	}
 	return []byte{}, fmt.Errorf("nil returned from getting etcd CA certificate by purpose %s", secret.ManagedExternalEtcdCA)

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"strings"
 
@@ -20,10 +19,11 @@ func (r *EtcdadmClusterReconciler) updateStatus(ctx context.Context, ec *etcdv1.
 	// This is necessary for CRDs including scale subresources.
 	ec.Status.Selector = selector.String()
 
-	log.Info("following machines owned by this etcd cluster:")
+	machineNameList := []string{}
 	for _, machine := range ownedMachines {
-		fmt.Printf("%s ", machine.Name)
+		machineNameList = append(machineNameList, machine.Name)
 	}
+	log.Info("following machines owned by this etcd cluster", "OwnedMachines", machineNameList)
 
 	desiredReplicas := *ec.Spec.Replicas
 	ec.Status.ReadyReplicas = int32(len(ownedMachines))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/1324

*Description of changes:*
There are some cases where the health checks for a ETCD machine get triggered before the ETCD certs are created. Healthchecks rely on the creation of these certs to establish a secure TLS connection with the ETCD nodes to make sure they are available and healthy.
If the certs are not available, etcdadm controller can panic causing the entire pod to crash.
This PR addresses this issue by adding a preflight to skip healthchecks if the ETCD certs are not available and ready.
It also adds a check to ensure the `KeyPair` pointer here is not nil before dereferencing it
https://github.com/aws/etcdadm-controller/blob/95b6ee33f544501ca8c8ef2cadfe547d20027213/controllers/certs.go#L143

I have also made some logging improvements to include the cluster name in log lines so the logs for specific cluster are easily identifiable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
