### PR TITLE
Increase `etcdadm-controller` CPU and memory limits

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -37,10 +37,10 @@ spec:
         name: manager
         resources:
           limits:
-            cpu: 100m
-            memory: 100Mi
+            cpu: 200m
+            memory: 256Mi
           requests:
             cpu: 100m
-            memory: 50Mi
+            memory: 64Mi
       terminationGracePeriodSeconds: 10
       serviceAccountName: manager


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/1340

*Description of changes:*
`etcdadm-controller` can hit CPU and memory limits when a management cluster is managing several workload clusters.
Bumping up the CPU and memory limits should give the `etcdadm-controller` more head room to manage multiple `etcdadmclusters` without running into resource constraints.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
