### PR TITLE
Add concurrency to etcdadm-controller

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,13 +11,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.18'
+          go-version: '1.19'
           check-latest: true
           cache: true
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.51.2
+          # Disable package caching to avoid a double cache with setup-go.
+          skip-pkg-cache: true
+          args: --timeout 10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,4 @@
+run:
+  timeout: 10m
+  skip-dirs:
+    - "api/v1alpha3"

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -48,11 +48,12 @@ import (
 type EtcdadmClusterReconciler struct {
 	controller controller.Controller
 	client.Client
-	recorder              record.EventRecorder
-	uncachedClient        client.Reader
-	Log                   logr.Logger
-	Scheme                *runtime.Scheme
-	etcdHealthCheckConfig etcdHealthCheckConfig
+	recorder                record.EventRecorder
+	uncachedClient          client.Reader
+	Log                     logr.Logger
+	Scheme                  *runtime.Scheme
+	etcdHealthCheckConfig   etcdHealthCheckConfig
+	MaxConcurrentReconciles int
 }
 
 func (r *EtcdadmClusterReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, done <-chan struct{}) error {
@@ -60,6 +61,7 @@ func (r *EtcdadmClusterReconciler) SetupWithManager(ctx context.Context, mgr ctr
 		For(&etcdv1.EtcdadmCluster{}).
 		Owns(&clusterv1.Machine{}).
 		WithEventFilter(predicates.ResourceNotPaused(r.Log)).
+		WithOptions(controller.Options{MaxConcurrentReconciles: r.MaxConcurrentReconciles}).
 		Build(r)
 	if err != nil {
 		return errors.Wrap(err, "failed setting up with a controller manager")

--- a/controllers/controller_test.go
+++ b/controllers/controller_test.go
@@ -442,7 +442,7 @@ func newEtcdadmCluster(cluster *clusterv1.Cluster) *etcdv1.EtcdadmCluster {
 					Version: "v3.4.9",
 				},
 			},
-			Replicas: pointer.Int32Ptr(int32(3)),
+			Replicas: pointer.Int32(int32(3)),
 			InfrastructureTemplate: corev1.ObjectReference{
 				Kind:       infraTemplate.GetKind(),
 				APIVersion: infraTemplate.GetAPIVersion(),

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	k8s.io/apimachinery v0.26.1
 	k8s.io/apiserver v0.26.1
 	k8s.io/client-go v0.26.1
+	k8s.io/klog/v2 v2.80.1
 	k8s.io/utils v0.0.0-20221128185143-99ec85e7a448
 	sigs.k8s.io/cluster-api v1.3.3
 	sigs.k8s.io/controller-runtime v0.14.5
@@ -88,7 +89,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.26.1 // indirect
 	k8s.io/cluster-bootstrap v0.25.0 // indirect
 	k8s.io/component-base v0.26.1 // indirect
-	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/main.go
+++ b/main.go
@@ -56,13 +56,14 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var maxConcurrentReconciles int
 	flag.StringVar(&metricsAddr, "metrics-addr", "localhost:8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&watchNamespace, "namespace", "",
 		"Namespace that the controller watches to reconcile etcdadmCluster objects. If unspecified, the controller watches for objects across all namespaces.")
-
+	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "The maximum number of concurrent etcdadm-controller reconciles.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -83,9 +84,10 @@ func main() {
 	// Setup the context that's going to be used in controllers and for the manager.
 	ctx, stopCh := setupSignalHandler()
 	etcdadmReconciler := &controllers.EtcdadmClusterReconciler{
-		Client: mgr.GetClient(),
-		Log:    ctrl.Log.WithName("controllers").WithName("EtcdadmCluster"),
-		Scheme: mgr.GetScheme(),
+		Client:                  mgr.GetClient(),
+		Log:                     ctrl.Log.WithName("controllers").WithName("EtcdadmCluster"),
+		Scheme:                  mgr.GetScheme(),
+		MaxConcurrentReconciles: maxConcurrentReconciles,
 	}
 	if err = (etcdadmReconciler).SetupWithManager(ctx, mgr, stopCh); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdadmCluster")


### PR DESCRIPTION
*Description of changes:*
This PR allows the `etcdadm-controller` to run 10 concurrent worker threads by default and also adds logic to configure this worker count through a flag `--max-concurrent-reconciles`.
This will help `etcdadm-controller` to reconcile multiple `etcdadm-cluster`s at a time, speeding up the process.

Also bumped up the `golangci-lint` version and added `"api/v1alpha3"` to skip-dirs for lint since it's using deprecated packages, which the linter complains about.

*Testing:*
Created and deleted 10 clusters simultaneously on vSphere and CloudStack and verified the cluster statuses.

On CloudStack, creating 10 clusters without this change took around 13 min and with this change took around 10 min.
There are still a few controllers that are currently sequential like `etcdadm-bootstrap-provider` and CAPC which this testing relied on. Making those concurrent will likely bring the cluster creation time down even more because it seemed like `etcdadm-controller` was bottlenecked by CAPC reconciling CAPC machines.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
