### PR TITLE
Add 2X replicas hard limit for Etcd

### DIFF
--- a/api/v1beta1/condition_consts.go
+++ b/api/v1beta1/condition_consts.go
@@ -11,6 +11,10 @@ const (
 	// rolling upgrade for aligning the machines spec to the desired state.
 	EtcdRollingUpdateInProgressReason = "EtcdRollingUpdateInProgress"
 
+	// EtcdMaxNumberOfMachinesReached (Severity=Warning) indicatest that there are 2X replicas while executing a
+	// rolling upgrade for aligning the machines spec to the desired state.
+	MaxNumberOfEtcdMachinesReachedReason = "MaxNumberOfEtcdMachinesReached"
+
 	// EtcdCertificatesAvailableCondition indicates that the etcdadm controller has generated the etcd certs to be used by new members
 	// joining the etcd cluster, and to be used by the controlplane
 	EtcdCertificatesAvailableCondition clusterv1.ConditionType = "EtcdCertificatesAvailable"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This adds a hard limit of having a maximum of 2X replicas total etcd machines when performing an upgrade to prevent etcd machines from rolling out indefinitely.

When there is more than 2X replicas, Etcd controller prints out `Cluster has reached the max number of machines, won't create new machines until at least one is deleted` and requeues it 

Also write to the condition etcdv1.EtcdMachinesSpecUpToDateCondition:
```
    Last Transition Time:  2023-07-19T18:12:01Z
    Message:               Etcd cluster has 6 total machines, maximum number of machines is 6
    Reason:                MaxNumberOfEtcdMachinesReached
    Severity:              Warning
    Status:                False
    Type:                  EtcdMachinesSpecUpToDate
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
