### PR TITLE
Fix Deleting out-of-date machines

### DIFF
--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -352,7 +352,7 @@ func (r *EtcdadmClusterReconciler) reconcileDelete(ctx context.Context, etcdClus
 	conditions.SetAggregate(etcdCluster, etcdv1.EtcdMachinesReadyCondition, ownedMachines.ConditionGetters(), conditions.AddSourceRef(), conditions.WithStepCounterIf(false))
 
 	// Delete etcd machines
-	machinesToDelete := ownedMachines.Filter(collections.Not(collections.HasDeletionTimestamp))
+	machinesToDelete := etcdMachines.Filter(collections.Not(collections.HasDeletionTimestamp))
 	var errs []error
 	for _, m := range machinesToDelete {
 		logger := log.WithValues("machine", m)

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -342,7 +342,7 @@ func (r *EtcdadmClusterReconciler) reconcileDelete(ctx context.Context, etcdClus
 
 	ownedMachines := etcdMachines.Filter(collections.OwnedMachines(etcdCluster))
 
-	if len(ownedMachines) == 0 {
+	if len(etcdMachines) == 0 {
 		// If no etcd machines are left, remove the finalizer
 		controllerutil.RemoveFinalizer(etcdCluster, etcdv1.EtcdadmClusterFinalizer)
 		return ctrl.Result{}, nil

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -340,13 +340,13 @@ func (r *EtcdadmClusterReconciler) reconcileDelete(ctx context.Context, etcdClus
 		return ctrl.Result{}, errors.Wrap(err, "Error filtering machines for etcd cluster")
 	}
 
-	ownedMachines := etcdMachines.Filter(collections.OwnedMachines(etcdCluster))
-
 	if len(etcdMachines) == 0 {
 		// If no etcd machines are left, remove the finalizer
 		controllerutil.RemoveFinalizer(etcdCluster, etcdv1.EtcdadmClusterFinalizer)
 		return ctrl.Result{}, nil
 	}
+
+	ownedMachines := etcdMachines.Filter(collections.OwnedMachines(etcdCluster))
 
 	// This aggregates the state of all machines
 	conditions.SetAggregate(etcdCluster, etcdv1.EtcdMachinesReadyCondition, ownedMachines.ConditionGetters(), conditions.AddSourceRef(), conditions.WithStepCounterIf(false))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-anywhere-internal/issues/1626

*Description of changes:*
We should only remove the finalizer on the EtcdadmCluster when all machines have been deleted. Otherwise there may be a situation where out-of-date machines never get cleaned up. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
