### PR TITLE
Close etcd client after use to avoid leaky routines

### DIFF
--- a/controllers/scale.go
+++ b/controllers/scale.go
@@ -54,6 +54,8 @@ func (r *EtcdadmClusterReconciler) removeEtcdMachine(ctx context.Context, ec *et
 	if etcdClient == nil {
 		return fmt.Errorf("could not create etcd client")
 	}
+	defer etcdClient.Close()
+
 	return r.removeEtcdMemberAndDeleteMachine(ctx, etcdClient, peerURL, machineToDelete)
 
 }


### PR DESCRIPTION
*Description of changes:*
Per the documentation (https://pkg.go.dev/go.etcd.io/etcd/client/v3):
> Make sure to close the client after using it. If the client is not closed, the connection will have leaky goroutines.

This explains the climb in goroutines we see when multiple etcd members become unhealthy. Since the healthcheck code will create one client per machine during the delete operation. These clients left routines running that never got cleaned up. This leaked routines probably explain as well the increase in memory usage we observed, although it's possible there are other issues contributing to it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
