### PR TITLE
Add annotation to configure healthcheck retries for EtcdadmCluster

### DIFF
--- a/api/v1beta1/etcdadmcluster_types.go
+++ b/api/v1beta1/etcdadmcluster_types.go
@@ -26,6 +26,8 @@ import (
 const (
 	UpgradeInProgressAnnotation = "etcdcluster.cluster.x-k8s.io/upgrading"
 
+	HealthCheckRetriesAnnotation = "etcdcluster.cluster.x-k8s.io/healthcheck-retries"
+
 	// EtcdadmClusterFinalizer is the finalizer applied to EtcdadmCluster resources
 	// by its managing controller.
 	EtcdadmClusterFinalizer = "etcdcluster.cluster.x-k8s.io"

--- a/controllers/controller.go
+++ b/controllers/controller.go
@@ -55,6 +55,7 @@ type EtcdadmClusterReconciler struct {
 	Scheme                  *runtime.Scheme
 	etcdHealthCheckConfig   etcdHealthCheckConfig
 	MaxConcurrentReconciles int
+	HealthCheckInterval     time.Duration
 	GetEtcdClient           func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error)
 	isPortOpen              func(ctx context.Context, endpoint string) bool
 }

--- a/controllers/periodic_healthcheck_test.go
+++ b/controllers/periodic_healthcheck_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/etcdadm-controller/controllers/mocks"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -15,8 +16,6 @@ import (
 )
 
 func TestStartHealthCheckLoop(t *testing.T) {
-	_ = NewWithT(t)
-
 	ctrl := gomock.NewController(t)
 	mockEtcd := mocks.NewMockEtcdClient(ctrl)
 	mockRt := mocks.NewMockRoundTripper(ctrl)
@@ -27,7 +26,7 @@ func TestStartHealthCheckLoop(t *testing.T) {
 
 	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdTest.gatherObjects()...).Build()
 
-	etcdEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
+	mockEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
 		return mockEtcd, nil
 	}
 
@@ -35,7 +34,7 @@ func TestStartHealthCheckLoop(t *testing.T) {
 		Client:         fakeKubernetesClient,
 		uncachedClient: fakeKubernetesClient,
 		Log:            log.Log,
-		GetEtcdClient:  etcdEtcdClient,
+		GetEtcdClient:  mockEtcdClient,
 	}
 	mockHttpClient := &http.Client{
 		Transport: mockRt,
@@ -44,12 +43,97 @@ func TestStartHealthCheckLoop(t *testing.T) {
 	r.etcdHealthCheckConfig.clusterToHttpClient.Store(etcdTest.cluster.UID, mockHttpClient)
 	r.SetIsPortOpen(isPortOpenMock)
 
-	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(healthyEtcdResponse, nil).Times(3)
+	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(getHealthyEtcdResponse(), nil).Times(3)
 
 	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
 	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
 }
 
+func TestStartHealthCheckLoopWithNoRetries(t *testing.T) {
+	g := NewWithT(t)
+	ctrl := gomock.NewController(t)
+	mockEtcd := mocks.NewMockEtcdClient(ctrl)
+	mockRt := mocks.NewMockRoundTripper(ctrl)
+
+	etcdTest := newEtcdadmClusterTest()
+	etcdTest.buildClusterWithExternalEtcd().withHealthCheckRetries(0)
+	etcdTest.etcdadmCluster.Status.CreationComplete = true
+
+	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdTest.gatherObjects()...).Build()
+
+	mockEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
+		return mockEtcd, nil
+	}
+
+	r := &EtcdadmClusterReconciler{
+		Client:         fakeKubernetesClient,
+		uncachedClient: fakeKubernetesClient,
+		Log:            log.Log,
+		GetEtcdClient:  mockEtcdClient,
+	}
+	mockHttpClient := &http.Client{
+		Transport: mockRt,
+	}
+
+	r.etcdHealthCheckConfig.clusterToHttpClient.Store(etcdTest.cluster.UID, mockHttpClient)
+	r.SetIsPortOpen(isPortOpenMock)
+
+	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("error")).Times(3)
+
+	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
+	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+
+	g.Expect(etcdadmClusterMapper).To(BeEmpty())
+}
+
+func TestStartHealthCheckLoopWithCustomRetries(t *testing.T) {
+	g := NewWithT(t)
+	ctrl := gomock.NewController(t)
+	mockEtcd := mocks.NewMockEtcdClient(ctrl)
+	mockRt := mocks.NewMockRoundTripper(ctrl)
+	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
+
+	etcdTest := newEtcdadmClusterTest()
+	etcdTest.buildClusterWithExternalEtcd().withHealthCheckRetries(3)
+	etcdTest.etcdadmCluster.Status.CreationComplete = true
+
+	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdTest.gatherObjects()...).Build()
+	mockEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
+		return mockEtcd, nil
+	}
+
+	r := &EtcdadmClusterReconciler{
+		Client:         fakeKubernetesClient,
+		uncachedClient: fakeKubernetesClient,
+		Log:            log.Log,
+		GetEtcdClient:  mockEtcdClient,
+	}
+	mockHttpClient := &http.Client{
+		Transport: mockRt,
+	}
+
+	r.etcdHealthCheckConfig.clusterToHttpClient.Store(etcdTest.cluster.UID, mockHttpClient)
+	r.SetIsPortOpen(isPortOpenMock)
+
+	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("error")).Times(9)
+	mockEtcd.EXPECT().MemberList(gomock.Any()).Return(etcdTest.getMemberListResponse(), nil).Times(3)
+	mockEtcd.EXPECT().Close().Times(3)
+
+	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+	g.Expect(etcdTest.getDeletedMachines(fakeKubernetesClient)).To(BeEmpty())
+
+	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+	g.Expect(etcdTest.getDeletedMachines(fakeKubernetesClient)).To(BeEmpty())
+
+	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+	g.Expect(etcdTest.getDeletedMachines(fakeKubernetesClient)).To(HaveLen(3))
+}
+
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (fn RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return fn(r)
+}
 
 func isPortOpenMock(_ context.Context, _ string) bool {
 	return true

--- a/controllers/scale.go
+++ b/controllers/scale.go
@@ -45,6 +45,7 @@ func (r *EtcdadmClusterReconciler) scaleDownEtcdCluster(ctx context.Context, ec 
 	machineAddress := getEtcdMachineAddress(machineToDelete)
 	return ctrl.Result{}, r.removeEtcdMachine(ctx, ec, cluster, machineToDelete, machineAddress)
 }
+
 func (r *EtcdadmClusterReconciler) removeEtcdMachine(ctx context.Context, ec *etcdv1.EtcdadmCluster, cluster *clusterv1.Cluster, machineToDelete *clusterv1.Machine, machineAddress string) error {
 	peerURL := fmt.Sprintf("https://%s:2380", machineAddress)
 	etcdClient, err := r.GetEtcdClient(ctx, cluster, ec.Status.Endpoints)

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.19
 require (
 	github.com/aws/etcdadm-bootstrap-provider v1.0.9
 	github.com/go-logr/logr v1.2.3
+	github.com/golang/mock v1.4.4
+	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/ginkgo/v2 v2.9.2
 	github.com/onsi/gomega v1.27.5
@@ -45,13 +47,11 @@ require (
 	github.com/gobuffalo/flect v1.0.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/mock v1.4.4 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	etcdbp "github.com/aws/etcdadm-bootstrap-provider/api/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -57,6 +58,7 @@ func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
 	var maxConcurrentReconciles int
+	var healthcheckInterval int
 	flag.StringVar(&metricsAddr, "metrics-addr", "localhost:8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
@@ -64,6 +66,7 @@ func main() {
 	flag.StringVar(&watchNamespace, "namespace", "",
 		"Namespace that the controller watches to reconcile etcdadmCluster objects. If unspecified, the controller watches for objects across all namespaces.")
 	flag.IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 10, "The maximum number of concurrent etcdadm-controller reconciles.")
+	flag.IntVar(&healthcheckInterval, "healthcheck-interval", 30, "The time interval between each healthcheck loop in seconds.")
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
@@ -88,6 +91,7 @@ func main() {
 		Log:                     ctrl.Log.WithName("controllers").WithName("EtcdadmCluster"),
 		Scheme:                  mgr.GetScheme(),
 		MaxConcurrentReconciles: maxConcurrentReconciles,
+		HealthCheckInterval:     time.Second * time.Duration(healthcheckInterval),
 	}
 	if err = (etcdadmReconciler).SetupWithManager(ctx, mgr, stopCh); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EtcdadmCluster")


### PR DESCRIPTION
*Description of changes:*
This PR adds an annotation `etcdcluster.cluster.x-k8s.io/healthcheck-paused` which when added to the `EtcdadmCluster`, pauses healthchecks for all the ETCD machines for that cluster.

It also makes the healthcheck interval configurable using the `--healthcheck-interval` flag, with the same default of 30 seconds. This also helps with unit tests since we can change this value so the unit tests don't have to wait 30 seconds just for a healthcheck loop.

Also added a unit test that verifies that the healthcheck is paused when the annotation is set on the `EtcdadmCluster` object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
