### PR TITLE
Periodic healthcheck improvements

### DIFF
--- a/api/v1beta1/etcdadmcluster_types.go
+++ b/api/v1beta1/etcdadmcluster_types.go
@@ -26,6 +26,7 @@ import (
 const (
 	UpgradeInProgressAnnotation = "etcdcluster.cluster.x-k8s.io/upgrading"
 
+	// HealthCheckRetriesAnnotation allows users to configure healthcheck retries. When set to 0, it disables healthchecks.
 	HealthCheckRetriesAnnotation = "etcdcluster.cluster.x-k8s.io/healthcheck-retries"
 
 	// EtcdadmClusterFinalizer is the finalizer applied to EtcdadmCluster resources

--- a/controllers/periodic_healthcheck_test.go
+++ b/controllers/periodic_healthcheck_test.go
@@ -2,31 +2,37 @@ package controllers
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+
+	. "github.com/onsi/gomega"
 
 	"github.com/aws/etcdadm-controller/controllers/mocks"
 	"github.com/golang/mock/gomock"
-	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
+
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestStartHealthCheckLoop(t *testing.T) {
+	_ = NewWithT(t)
+
 	ctrl := gomock.NewController(t)
 	mockEtcd := mocks.NewMockEtcdClient(ctrl)
 	mockRt := mocks.NewMockRoundTripper(ctrl)
 
-	etcdTest := newEtcdadmClusterTest()
+	etcdTest := newEtcdadmClusterTest(3)
 	etcdTest.buildClusterWithExternalEtcd()
 	etcdTest.etcdadmCluster.Status.CreationComplete = true
 
 	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdTest.gatherObjects()...).Build()
 
-	mockEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
+	etcdEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
 		return mockEtcd, nil
 	}
 
@@ -34,7 +40,7 @@ func TestStartHealthCheckLoop(t *testing.T) {
 		Client:         fakeKubernetesClient,
 		uncachedClient: fakeKubernetesClient,
 		Log:            log.Log,
-		GetEtcdClient:  mockEtcdClient,
+		GetEtcdClient:  etcdEtcdClient,
 	}
 	mockHttpClient := &http.Client{
 		Transport: mockRt,
@@ -55,7 +61,7 @@ func TestStartHealthCheckLoopWithNoRetries(t *testing.T) {
 	mockEtcd := mocks.NewMockEtcdClient(ctrl)
 	mockRt := mocks.NewMockRoundTripper(ctrl)
 
-	etcdTest := newEtcdadmClusterTest()
+	etcdTest := newEtcdadmClusterTest(3)
 	etcdTest.buildClusterWithExternalEtcd().withHealthCheckRetries(0)
 	etcdTest.etcdadmCluster.Status.CreationComplete = true
 
@@ -93,9 +99,11 @@ func TestStartHealthCheckLoopWithCustomRetries(t *testing.T) {
 	mockRt := mocks.NewMockRoundTripper(ctrl)
 	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
 
-	etcdTest := newEtcdadmClusterTest()
+	etcdTest := newEtcdadmClusterTest(3)
 	etcdTest.buildClusterWithExternalEtcd().withHealthCheckRetries(3)
 	etcdTest.etcdadmCluster.Status.CreationComplete = true
+
+	ip := etcdTest.machines[0].Status.Addresses[0].Address
 
 	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdTest.gatherObjects()...).Build()
 	mockEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
@@ -109,7 +117,12 @@ func TestStartHealthCheckLoopWithCustomRetries(t *testing.T) {
 		GetEtcdClient:  mockEtcdClient,
 	}
 	mockHttpClient := &http.Client{
-		Transport: mockRt,
+		Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.Host, ip) {
+				return nil, fmt.Errorf("Error")
+			}
+			return getHealthyEtcdResponse(), nil
+		}),
 	}
 
 	r.etcdHealthCheckConfig.clusterToHttpClient.Store(etcdTest.cluster.UID, mockHttpClient)
@@ -126,7 +139,162 @@ func TestStartHealthCheckLoopWithCustomRetries(t *testing.T) {
 	g.Expect(etcdTest.getDeletedMachines(fakeKubernetesClient)).To(BeEmpty())
 
 	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
-	g.Expect(etcdTest.getDeletedMachines(fakeKubernetesClient)).To(HaveLen(3))
+	g.Expect(etcdTest.getDeletedMachines(fakeKubernetesClient)).To(HaveLen(1))
+}
+
+func TestReconcilePeriodicHealthCheckMachineToBeDeletedNowHealthy(t *testing.T) {
+	g := NewWithT(t)
+
+	ctrl := gomock.NewController(t)
+	mockEtcd := mocks.NewMockEtcdClient(ctrl)
+	mockRt := mocks.NewMockRoundTripper(ctrl)
+
+	etcdadmCluster := newEtcdadmClusterTest(1)
+	etcdadmCluster.buildClusterWithExternalEtcd()
+	etcdadmCluster.etcdadmCluster.Status.CreationComplete = true
+
+	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdadmCluster.gatherObjects()...).Build()
+
+	etcdEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
+		return mockEtcd, nil
+	}
+
+	r := &EtcdadmClusterReconciler{
+		Client:         fakeKubernetesClient,
+		uncachedClient: fakeKubernetesClient,
+		Log:            log.Log,
+		GetEtcdClient:  etcdEtcdClient,
+	}
+	mockHttpClient := &http.Client{
+		Transport: mockRt,
+	}
+
+	r.etcdHealthCheckConfig.clusterToHttpClient.Store(etcdadmCluster.cluster.UID, mockHttpClient)
+	r.SetIsPortOpen(isPortOpenMock)
+
+	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
+
+	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("error")).Times(5)
+	mockEtcd.EXPECT().MemberList(gomock.Any()).Return(etcdadmCluster.getMemberListResponse(), nil).Times(5)
+	mockEtcd.EXPECT().Close().Times(5)
+
+	for i := 0; i < 5; i++ {
+		r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+	}
+
+	g.Expect(etcdadmClusterMapper[etcdadmCluster.etcdadmCluster.UID].unhealthyMembersToRemove).To(HaveLen(1))
+
+	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(getHealthyEtcdResponse(), nil)
+	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+
+	g.Expect(etcdadmClusterMapper[etcdadmCluster.etcdadmCluster.UID].unhealthyMembersToRemove).To(HaveLen(0))
+}
+
+func TestQuorumNotPreserved(t *testing.T) {
+	g := NewWithT(t)
+
+	ctrl := gomock.NewController(t)
+	mockEtcd := mocks.NewMockEtcdClient(ctrl)
+	mockRt := mocks.NewMockRoundTripper(ctrl)
+
+	etcdTest := newEtcdadmClusterTest(3)
+	etcdTest.buildClusterWithExternalEtcd()
+	etcdTest.etcdadmCluster.Status.CreationComplete = true
+
+	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdTest.gatherObjects()...).Build()
+
+	etcdEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
+		return mockEtcd, nil
+	}
+
+	r := &EtcdadmClusterReconciler{
+		Client:         fakeKubernetesClient,
+		uncachedClient: fakeKubernetesClient,
+		Log:            log.Log,
+		GetEtcdClient:  etcdEtcdClient,
+	}
+	mockHttpClient := &http.Client{
+		Transport: mockRt,
+	}
+
+	r.etcdHealthCheckConfig.clusterToHttpClient.Store(etcdTest.cluster.UID, mockHttpClient)
+	r.SetIsPortOpen(isPortOpenMock)
+
+	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
+
+	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("error")).Times(15)
+	mockEtcd.EXPECT().MemberList(gomock.Any()).Return(etcdTest.getMemberListResponse(), nil).Times(5)
+	mockEtcd.EXPECT().Close().Times(5)
+
+	for i := 0; i < 5; i++ {
+		r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+	}
+
+	unhealthyList := len(etcdadmClusterMapper[etcdTest.etcdadmCluster.UID].unhealthyMembersToRemove)
+	g.Expect(unhealthyList).To(Equal(3))
+
+	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("error")).Times(9)
+	mockEtcd.EXPECT().MemberList(gomock.Any()).Times(3)
+	mockEtcd.EXPECT().Close().Times(3)
+	for i := 0; i < 3; i++ {
+		r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+	}
+
+	machineList := &clusterv1.MachineList{}
+	g.Expect(fakeKubernetesClient.List(context.Background(), machineList)).To(Succeed())
+	for _, m := range machineList.Items {
+		g.Expect(m.DeletionTimestamp.IsZero()).To(BeTrue())
+	}
+	g.Expect(etcdadmClusterMapper[etcdTest.etcdadmCluster.UID].unhealthyMembersToRemove).To(HaveLen(3))
+}
+
+func TestQuorumPreserved(t *testing.T) {
+	g := NewWithT(t)
+
+	ctrl := gomock.NewController(t)
+	mockEtcd := mocks.NewMockEtcdClient(ctrl)
+
+	etcdTest := newEtcdadmClusterTest(5)
+	etcdTest.buildClusterWithExternalEtcd()
+	etcdTest.etcdadmCluster.Status.CreationComplete = true
+
+	ip1 := etcdTest.machines[0].Status.Addresses[0].Address
+	ip2 := etcdTest.machines[1].Status.Addresses[0].Address
+
+	fakeKubernetesClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(etcdTest.gatherObjects()...).Build()
+
+	etcdEtcdClient := func(ctx context.Context, cluster *clusterv1.Cluster, endpoints string) (EtcdClient, error) {
+		return mockEtcd, nil
+	}
+
+	r := &EtcdadmClusterReconciler{
+		Client:         fakeKubernetesClient,
+		uncachedClient: fakeKubernetesClient,
+		Log:            log.Log,
+		GetEtcdClient:  etcdEtcdClient,
+	}
+	mockHttpClient := &http.Client{
+		Transport: RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if strings.Contains(req.Host, ip1) || strings.Contains(req.Host, ip2) {
+				return nil, fmt.Errorf("Error")
+			}
+			return getHealthyEtcdResponse(), nil
+		}),
+	}
+
+	r.etcdHealthCheckConfig.clusterToHttpClient.Store(etcdTest.cluster.UID, mockHttpClient)
+	r.SetIsPortOpen(isPortOpenMock)
+
+	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
+
+	mockEtcd.EXPECT().MemberList(gomock.Any()).Return(etcdTest.getMemberListResponse(), nil).Times(5)
+	mockEtcd.EXPECT().Close().Times(5)
+	for i := 0; i < 5; i++ {
+		r.startHealthCheck(context.Background(), etcdadmClusterMapper)
+	}
+
+	g.Expect(etcdadmClusterMapper[etcdTest.etcdadmCluster.UID].unhealthyMembersFrequency).To(HaveLen(2))
+	g.Expect(etcdTest.getDeletedMachines(fakeKubernetesClient)).To(HaveLen(1))
 }
 
 type RoundTripperFunc func(*http.Request) (*http.Response, error)

--- a/controllers/status.go
+++ b/controllers/status.go
@@ -67,7 +67,7 @@ func (r *EtcdadmClusterReconciler) updateStatus(ctx context.Context, ec *etcdv1.
 	sort.Strings(endpoints)
 	currEndpoints := strings.Join(endpoints, ",")
 
-	log.Info("Comparing current and previous endpoints")
+	log.Info("Comparing current and previous endpoints", "current endpoints", currEndpoints, "previous endpoints", ec.Status.Endpoints)
 	// Checking if endpoints have changed. This avoids unnecessary client calls
 	// to get and update the Secret containing the endpoints
 	if ec.Status.Endpoints != currEndpoints {

--- a/controllers/testutils.go
+++ b/controllers/testutils.go
@@ -60,13 +60,15 @@ type etcdadmClusterTest struct {
 	cluster        *clusterv1.Cluster
 	etcdadmCluster *etcdv1.EtcdadmCluster
 	machines       []*clusterv1.Machine
+	machineCounter int
 }
 
-func newEtcdadmClusterTest() *etcdadmClusterTest {
+func newEtcdadmClusterTest(etcdReplicas int) *etcdadmClusterTest {
 	return &etcdadmClusterTest{
-		name:      testClusterName,
-		namespace: testNamespace,
-		replicas:  3,
+		name:           testClusterName,
+		namespace:      testNamespace,
+		replicas:       etcdReplicas,
+		machineCounter: 0,
 	}
 }
 
@@ -157,7 +159,7 @@ func (e *etcdadmClusterTest) newEtcdadmCluster(cluster *clusterv1.Cluster) *etcd
 }
 
 func (e *etcdadmClusterTest) newEtcdMachine() *clusterv1.Machine {
-	return &clusterv1.Machine{
+	etcdMachine := &clusterv1.Machine{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Machine",
 			APIVersion: clusterv1.GroupVersion.String(),
@@ -190,6 +192,8 @@ func (e *etcdadmClusterTest) newEtcdMachine() *clusterv1.Machine {
 			},
 		},
 	}
+	e.machineCounter++
+	return etcdMachine
 }
 
 func (e *etcdadmClusterTest) gatherObjects() []client.Object {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Fix bug where if machine passes healthcheck, is not deleted from queue to be deleted. Add delete(currClusterHFConfig.unhealthyMembersToRemove, endpoint) to line 150 in periodic_healthcheck.
2. Limit number of machines to be deleted in healthcheck to delete one machine at a time and always wait for the new replica to be created before deleting another one. This should be easy to do by just checking what's the desired number of replicas.
3.  To make sure we preserve quorum, check if it's safe to remove a machine as a member: currentTotalMembers - unhealthyMembers >= currentTotalMembers/2 + 1. Here currentTotalMembers and unhealthyMembers needs to take into account all machines that part of the etcd cluster and not only the owned ones. 
4. Perform healthchecks iterating over the all machines instead of status.endpoints. Endpoints in the status might not always be updated. In fact with the way the code is structured, the status is not updated until all the machines marked for deletion are successfully deleted. Ignore machines in bootstrapping phase.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
