### PR TITLE
Add actions for vulnerability scans

### DIFF
--- a/.github/workflows/vulnerability.yml
+++ b/.github/workflows/vulnerability.yml
@@ -1,0 +1,36 @@
+name: "Vulnerability scan"
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    # every day at 7am UTC
+    - cron: '0 7 * * *'
+permissions:
+  contents: read
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: "Dependency Review"
+        uses: actions/dependency-review-action@v3
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+      - name: govulncheck
+        uses: golang/govulncheck-action@v1
+        with:
+          repo-checkout: false
+          go-version-file: go.mod


### PR DESCRIPTION
*Description of changes:*
This should prevent vulnerable deps from being added and also will scan our code to narrow down if we are affecting by new CEV or not. This will run on every PR, every commit to main and periodically every night.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
