### PR TITLE
Remove webhook blocking etcd scaling

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -20,7 +20,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.55.2
           # Disable package caching to avoid a double cache with setup-go.
           skip-pkg-cache: true
           args: --timeout 10m

--- a/api/v1beta1/etcdadmcluster_webhook.go
+++ b/api/v1beta1/etcdadmcluster_webhook.go
@@ -17,8 +17,6 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
-
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -72,15 +70,6 @@ func (r *EtcdadmCluster) ValidateCreate() error {
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *EtcdadmCluster) ValidateUpdate(old runtime.Object) error {
 	etcdadmclusterlog.Info("validate update", "name", r.Name)
-
-	oldEtcdadmCluster, ok := old.(*EtcdadmCluster)
-	if !ok {
-		return apierrors.NewBadRequest(fmt.Sprintf("expected an EtcdadmCluster object but got a %T", old))
-	}
-
-	if *oldEtcdadmCluster.Spec.Replicas != *r.Spec.Replicas {
-		return field.Invalid(field.NewPath("spec", "replicas"), r.Spec.Replicas, "field is immutable")
-	}
 
 	allErrs := r.validateCommon()
 	if len(allErrs) > 0 {

--- a/api/v1beta1/etcdadmcluster_webhook_test.go
+++ b/api/v1beta1/etcdadmcluster_webhook_test.go
@@ -1,0 +1,154 @@
+/*
+
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+)
+
+func TestValidateCreate(t *testing.T) {
+	cases := map[string]struct {
+		in        *EtcdadmCluster
+		expectErr string
+	}{
+		"valid etcdadm cluster": {
+			in: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(3)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "",
+		},
+		"no replicas field": {
+			in: &EtcdadmCluster{
+				Spec:   EtcdadmClusterSpec{},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "spec.replicas: Required value: is required",
+		},
+		"zero replicas": {
+			in: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(0)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "cannot be less than or equal to 0",
+		},
+		"even replicas": {
+			in: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(2)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "Forbidden: etcd cluster cannot have an even number of nodes",
+		},
+		"mismatched namespace": {
+			in: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(3)),
+					InfrastructureTemplate: corev1.ObjectReference{
+						Namespace: "fail",
+					},
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "Invalid value: \"fail\": must match metadata.namespace",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := tt.in.ValidateCreate()
+			if tt.expectErr == "" {
+				g.Expect(err).To(BeNil())
+			} else {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.expectErr)))
+			}
+		})
+	}
+}
+func TestValidateUpdate(t *testing.T) {
+	cases := map[string]struct {
+		oldConf   *EtcdadmCluster
+		newConf   *EtcdadmCluster
+		expectErr string
+	}{
+		"valid scale up": {
+			oldConf: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(3)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			newConf: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(5)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "",
+		},
+		"valid scale down": {
+			oldConf: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(3)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			newConf: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(1)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "",
+		},
+		"zero replicas": {
+			oldConf: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(3)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			newConf: &EtcdadmCluster{
+				Spec: EtcdadmClusterSpec{
+					Replicas: pointer.Int32(int32(0)),
+				},
+				Status: EtcdadmClusterStatus{},
+			},
+			expectErr: "cannot be less than or equal to 0",
+		},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			g := NewWithT(t)
+			err := tt.newConf.ValidateUpdate(tt.oldConf)
+			if tt.expectErr != "" {
+				g.Expect(err).To(MatchError(ContainSubstring(tt.expectErr)))
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+		})
+	}
+}

--- a/controllers/etcd_plane.go
+++ b/controllers/etcd_plane.go
@@ -142,6 +142,15 @@ func (ep *EtcdPlane) MachinesNeedingRollout() collections.Machines {
 	)
 }
 
+// OutOfDateMachines return a list of all machines with an out of date config.
+func (ep *EtcdPlane) OutOfDateMachines() collections.Machines {
+	// Return machines if they are scheduled for rollout or if with an outdated configuration.
+	return ep.Machines.AnyFilter(
+		//Machines that do not match with Etcdadm config.
+		collections.Not(MatchesEtcdadmClusterConfiguration(ep.infraResources, ep.etcdadmConfigs, ep.EC)),
+	)
+}
+
 // MatchesEtcdadmClusterConfiguration returns a filter to find all machines that matches with EtcdadmCluster config and do not require any rollout.
 // Etcd version and extra params, and infrastructure template need to be equivalent.
 func MatchesEtcdadmClusterConfiguration(infraConfigs map[string]*unstructured.Unstructured, machineConfigs map[string]*etcdbootstrapv1.EtcdadmConfig, ec *etcdv1.EtcdadmCluster) func(machine *clusterv1.Machine) bool {

--- a/controllers/etcd_plane_test.go
+++ b/controllers/etcd_plane_test.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	"testing"
+
+	etcdbootstrapv1 "github.com/aws/etcdadm-bootstrap-provider/api/v1beta1"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestOutOfDateMachines(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := newClusterWithExternalEtcd()
+	etcdadmCluster := newEtcdadmCluster(cluster)
+
+	machine1 := newEtcdMachine(etcdadmCluster, cluster)
+
+	objects := []client.Object{
+		cluster,
+		etcdadmCluster,
+		infraTemplate.DeepCopy(),
+		machine1,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+
+	machines := map[string]*clusterv1.Machine{
+		machine1.Name: machine1,
+	}
+
+	etcdadmConfigs, err := getEtcdadmConfigs(ctx, fakeClient, machines)
+	g.Expect(err).ToNot(HaveOccurred())
+	infraResources, err := getInfraResources(ctx, fakeClient, machines)
+	g.Expect(err).ToNot(HaveOccurred())
+
+	// build EtcdPlane for test
+	ep := &EtcdPlane{
+		EC:             etcdadmCluster,
+		Cluster:        cluster,
+		Machines:       machines,
+		etcdadmConfigs: etcdadmConfigs,
+		infraResources: infraResources,
+	}
+
+	outdatedMachines := ep.OutOfDateMachines()
+	g.Expect(len(outdatedMachines)).To(Equal(0))
+
+	// change etcdadmConfig for machine
+	ep.etcdadmConfigs[machine1.Name] = &etcdbootstrapv1.EtcdadmConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      testClusterName,
+		},
+		Spec: etcdbootstrapv1.EtcdadmConfigSpec{
+			EtcdadmInstallCommands: []string{"etcdadmInstallCommands is not empty"},
+			CloudInitConfig: &etcdbootstrapv1.CloudInitConfig{
+				Version: "v3.4.9",
+			},
+		},
+	}
+
+	// check that machine is in outdated machines
+	outdatedMachines = ep.OutOfDateMachines()
+	g.Expect(len(outdatedMachines)).To(Equal(1))
+}

--- a/controllers/periodic_healthcheck_test.go
+++ b/controllers/periodic_healthcheck_test.go
@@ -130,6 +130,7 @@ func TestStartHealthCheckLoopWithCustomRetries(t *testing.T) {
 
 	mockRt.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("error")).Times(9)
 	mockEtcd.EXPECT().MemberList(gomock.Any()).Return(etcdTest.getMemberListResponse(), nil).Times(3)
+	mockEtcd.EXPECT().MemberRemove(gomock.Any(), gomock.Any()).Return(etcdTest.getMemberRemoveResponse(), nil).Times(1)
 	mockEtcd.EXPECT().Close().Times(3)
 
 	r.startHealthCheck(context.Background(), etcdadmClusterMapper)
@@ -288,6 +289,7 @@ func TestQuorumPreserved(t *testing.T) {
 	etcdadmClusterMapper := make(map[types.UID]etcdadmClusterMemberHealthConfig)
 
 	mockEtcd.EXPECT().MemberList(gomock.Any()).Return(etcdTest.getMemberListResponse(), nil).Times(5)
+	mockEtcd.EXPECT().MemberRemove(gomock.Any(), gomock.Any()).Return(etcdTest.getMemberRemoveResponse(), nil).Times(1)
 	mockEtcd.EXPECT().Close().Times(5)
 	for i := 0; i < 5; i++ {
 		r.startHealthCheck(context.Background(), etcdadmClusterMapper)

--- a/controllers/status_test.go
+++ b/controllers/status_test.go
@@ -1,0 +1,120 @@
+package controllers
+
+import (
+	"testing"
+
+	etcdv1 "github.com/aws/etcdadm-controller/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestUpdateStatusResizeIncomplete(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := newClusterWithExternalEtcd()
+	etcdadmCluster := newEtcdadmCluster(cluster)
+
+	machine1 := newEtcdMachine(etcdadmCluster, cluster)
+	machine2 := newEtcdMachine(etcdadmCluster, cluster)
+
+	etcdMachine1 := etcdMachine{
+		Machine:     machine1,
+		endpoint:    "1.1.1.1",
+		listening:   true,
+		healthError: nil,
+	}
+	etcdMachine2 := etcdMachine{
+		Machine:     machine2,
+		endpoint:    "1.1.1.1",
+		listening:   true,
+		healthError: nil,
+	}
+
+	ownedMachines := map[string]etcdMachine{
+		"machine1": etcdMachine1,
+		"machine2": etcdMachine2,
+	}
+
+	objects := []client.Object{
+		cluster,
+		etcdadmCluster,
+		infraTemplate.DeepCopy(),
+		machine1,
+		machine2,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+
+	r := &EtcdadmClusterReconciler{
+		Client:         fakeClient,
+		uncachedClient: fakeClient,
+		Log:            log.Log,
+	}
+
+	err := r.updateStatus(ctx, etcdadmCluster, cluster, ownedMachines)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(conditions.IsTrue(etcdadmCluster, etcdv1.EtcdClusterResizeCompleted)).To(BeFalse())
+}
+
+func TestUpdateStatusResizeComplete(t *testing.T) {
+	g := NewWithT(t)
+
+	cluster := newClusterWithExternalEtcd()
+	etcdadmCluster := newEtcdadmCluster(cluster)
+
+	machine1 := newEtcdMachine(etcdadmCluster, cluster)
+	machine2 := newEtcdMachine(etcdadmCluster, cluster)
+	machine3 := newEtcdMachine(etcdadmCluster, cluster)
+
+	etcdMachine1 := etcdMachine{
+		Machine:     machine1,
+		endpoint:    "1.1.1.1",
+		listening:   true,
+		healthError: nil,
+	}
+	etcdMachine2 := etcdMachine{
+		Machine:     machine2,
+		endpoint:    "1.1.1.1",
+		listening:   true,
+		healthError: nil,
+	}
+	etcdMachine3 := etcdMachine{
+		Machine:     machine3,
+		endpoint:    "1.1.1.1",
+		listening:   true,
+		healthError: nil,
+	}
+
+	ownedMachines := map[string]etcdMachine{
+		"machine1": etcdMachine1,
+		"machine2": etcdMachine2,
+		"machine3": etcdMachine3,
+	}
+
+	objects := []client.Object{
+		cluster,
+		etcdadmCluster,
+		infraTemplate.DeepCopy(),
+		machine1,
+		machine2,
+		machine3,
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(setupScheme()).WithObjects(objects...).Build()
+
+	r := &EtcdadmClusterReconciler{
+		Client:         fakeClient,
+		uncachedClient: fakeClient,
+		Log:            log.Log,
+	}
+
+	err := r.updateStatus(ctx, etcdadmCluster, cluster, ownedMachines)
+	// Init secret not defined, so error will occur. This test checks that the resizeComplete condition is properly set
+	// which happens before the updating init secret stage of updateStatus.
+	g.Expect(err).To(HaveOccurred())
+	g.Expect(conditions.IsTrue(etcdadmCluster, etcdv1.EtcdClusterResizeCompleted)).To(BeTrue())
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes webhook blocking etcd replicas from being changed to enable etcd scaling

With testing of etcd scaling, we saw two issues:
1. there was an issue with etcd marking cluster as ready as soon as the new machines got provisioned, without waiting for the machines to be running/ready when scaling up/down
2. there was an issue with kcp never rolling out after etcd scaled because the etcd upgrade in progress annotation was never removed after scaling

Added changes to fix these issues as well. 

Additionally, changed condition for max number of etcd replicas from 2x desired replicas to `num all outdated machines + desired replicas` to account for edge case if scaling down etcd replicas and also doing an upgrade

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
