### PR TITLE
Update endpoint IP selection order based on address type found

### DIFF
--- a/controllers/helpers_test.go
+++ b/controllers/helpers_test.go
@@ -1,0 +1,92 @@
+package controllers
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+)
+
+func TestGetEtcdMachineAddress(t *testing.T) {
+	g := NewWithT(t)
+	type test struct {
+		machine        clusterv1.Machine
+		AvailAddrTypes clusterv1.MachineAddresses
+		wantAddr       string
+	}
+
+	capiMachine := clusterv1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "machine",
+		},
+		Spec: clusterv1.MachineSpec{
+			ClusterName: "test-cluster",
+		},
+		Status: clusterv1.MachineStatus{},
+	}
+	tests := []test{
+		{
+			machine: capiMachine,
+			AvailAddrTypes: clusterv1.MachineAddresses{
+				clusterv1.MachineAddress{
+					Type:    clusterv1.MachineInternalIP,
+					Address: "1.1.1.1",
+				}, clusterv1.MachineAddress{
+					Type:    clusterv1.MachineExternalIP,
+					Address: "2.2.2.2",
+				},
+			},
+			wantAddr: "2.2.2.2",
+		}, {
+			machine: capiMachine,
+			AvailAddrTypes: []clusterv1.MachineAddress{
+				{
+					Type:    clusterv1.MachineInternalDNS,
+					Address: "1.1.1.1",
+				}, {
+					Type:    clusterv1.MachineExternalIP,
+					Address: "2.2.2.2",
+				},
+			},
+			wantAddr: "2.2.2.2",
+		}, {
+			machine: capiMachine,
+			AvailAddrTypes: []clusterv1.MachineAddress{
+				{
+					Type:    clusterv1.MachineInternalIP,
+					Address: "1.1.1.1",
+				}, {
+					Type:    clusterv1.MachineInternalDNS,
+					Address: "2.2.2.2",
+				},
+			},
+			wantAddr: "2.2.2.2",
+		}, {
+			machine: capiMachine,
+			AvailAddrTypes: []clusterv1.MachineAddress{
+				{
+					Type:    clusterv1.MachineExternalDNS,
+					Address: "1.1.1.1",
+				}, {
+					Type:    clusterv1.MachineInternalDNS,
+					Address: "2.2.2.2",
+				},
+			},
+			wantAddr: "1.1.1.1",
+		}, {
+			machine: capiMachine,
+			AvailAddrTypes: []clusterv1.MachineAddress{
+				{
+					Type:    clusterv1.MachineHostName,
+					Address: "1.1.1.1",
+				},
+			},
+			wantAddr: "",
+		},
+	}
+	for _, tc := range tests {
+		capiMachine.Status.Addresses = tc.AvailAddrTypes
+		g.Expect(getEtcdMachineAddress(&capiMachine)).To(Equal(tc.wantAddr))
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Currently, we set the etcd endpoint based on the address set on machine status and give preference to InternalIP/DNS over externalIP/DNS. CAPV introduced a [change](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/2529) in which they set the machine address of type InternalIP to be the vm name. This breaks the endpoint check logic we currently have as we would not have a DNS entry for the corresponding endpoint. In this change, we record all the address types found in the machine status and take a precedence based approach in which DNS entries take precedence over IPs and external type takes precedence over internal. We are excluding [HostName](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/blob/d4a5e72f026b31725437a0bbe7c6cebfc7277e16/apis/v1alpha4/vendored_cluster_api.go#L159) address type as it would again fail in our connection check.

*Testing:*
Built the controller and tested manually to be able to create clusters with CAPV 1.9.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
