### PR TITLE
Add nil pointer check for client cert key pairs

### DIFF
--- a/controllers/certs.go
+++ b/controllers/certs.go
@@ -169,6 +169,9 @@ func (r *EtcdadmClusterReconciler) getClientCerts(ctx context.Context, cluster *
 		return tls.Certificate{}, err
 	}
 	if clientCertKey := clientCert.GetByPurpose(secret.APIServerEtcdClient); clientCertKey != nil {
+		if clientCertKey.KeyPair == nil {
+			return tls.Certificate{}, fmt.Errorf("client cert key pair not found for cluster")
+		}
 		return tls.X509KeyPair(clientCertKey.KeyPair.Cert, clientCertKey.KeyPair.Key)
 	}
 	return tls.Certificate{}, fmt.Errorf("nil returned from getting etcd CA certificate by purpose %s", secret.APIServerEtcdClient)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
There was a nil pointer panic in etcdadm controller in the case that the `apiserver-etcd-client` secret got deleted.

This adds a nil pointer check for the client cert key pair to prevent this panic.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
