### PR TITLE
🐛 Drop caBundle from CRDs to support Kubernetes 1.31

### DIFF
--- a/config/crd/patches/webhook_in_etcdadmclusters.yaml
+++ b/config/crd/patches/webhook_in_etcdadmclusters.yaml
@@ -10,9 +10,6 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: system
           name: webhook-service


### PR DESCRIPTION
Signed-off-by: Saurabh Parekh [sjparekh@amazon.com](mailto:sjparekh@amazon.com)

**What this PR does / why we need it:**
Context: https://github.com/kubernetes-sigs/cluster-api/pull/10972

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
